### PR TITLE
Update Shebang in Linux Wrapper Script to /usr/bin/env bash

### DIFF
--- a/dist/linux_wrapper.sh
+++ b/dist/linux_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export SRC_DIR=$(cd "$(dirname "$0")"; pwd)
 


### PR DESCRIPTION
Updates the Shebang Line to

``` bash
#!/usr/bin/env bash
```

This is necessary because bash is not guaranteed to be in /bin but env is guaranteed to be in /usr/bin, therefore letting the environment be used to find the bash executable is appropriate.
