### PR TITLE
Add tab ID to 'tabs_get' method response

### DIFF
--- a/lib/core_tabs.js
+++ b/lib/core_tabs.js
@@ -688,6 +688,7 @@ var core_tabs = function(spec, my) {
       var tabs = [];
       Object.keys(my.tabs).forEach(function(id) {
         tabs.push({
+          id: id,
           state: my.tabs[id].state,
           loading: my.tabs[id].loading
         });


### PR DESCRIPTION
As discussed in issue #114 this fix will add the tab ID to the response object when not specifying a tab.

![breach-tabs-ids](https://cloud.githubusercontent.com/assets/945367/3620485/12d0c5d0-0e01-11e4-9b5a-68e5c2376164.png)

The screenshot above demonstrates the ID in action using the following snippet to get and log each tab.

``` javascript
breach.module('core').call('tabs_get', {}, function(err, res) {
  res.forEach(function(tab) {
    console.log(tab);
  });
});
```
