### PR TITLE
Add tabs list method (issue #152)

### DIFF
--- a/lib/core_module.js
+++ b/lib/core_module.js
@@ -488,6 +488,7 @@ var core_module = function(spec, my) {
     my.session.module_manager().core_expose('tabs_show', my.core_tabs.tabs_show);
     my.session.module_manager().core_expose('tabs_focus', my.core_tabs.tabs_focus);
     my.session.module_manager().core_expose('tabs_get', my.core_tabs.tabs_get);
+    my.session.module_manager().core_expose('tabs_list', my.core_tabs.tabs_list);
     my.session.module_manager().core_expose('tabs_load_url', my.core_tabs.tabs_load_url);
     my.session.module_manager().core_expose('tabs_back_or_forward', my.core_tabs.tabs_back_or_forward);
     my.session.module_manager().core_expose('tabs_reload', my.core_tabs.tabs_reload);

--- a/lib/core_tabs.js
+++ b/lib/core_tabs.js
@@ -60,6 +60,7 @@ var core_tabs = function(spec, my) {
   var tabs_show;                     /* tabs_show(args, cb_); */
   var tabs_focus;                    /* tabs_focus(args, cb_); */
   var tabs_get;                      /* tabs_get(args, cb_); */
+  var tabs_list;                     /* tabs_list(args, cb_); */
   var tabs_load_url;                 /* tabs_load_url(args, cb_); */
   var tabs_back_or_forward;          /* tabs_back_or_forward(args, cb_); */
   var tabs_reload;                   /* tabs_reload(args, cb_); */
@@ -685,16 +686,27 @@ var core_tabs = function(spec, my) {
       return cb_(null, tab);
     }
     else {
-      var tabs = [];
-      Object.keys(my.tabs).forEach(function(id) {
-        tabs.push({
-          id: id,
-          state: my.tabs[id].state,
-          loading: my.tabs[id].loading
-        });
-      });
-      return cb_(null, tabs);
+      return tabs_list(src, args, cb_);
     }
+  };
+  
+  // ### tabs_list
+  // 
+  // Returns a list of current tabs
+  // ```
+  // @src {string} source module
+  // @args {object} {}
+  // @cb_  {function(err, res)}
+  tabs_list = function(src, args, cb_) {
+    var tabs = [];
+    Object.keys(my.tabs).forEach(function(id) {
+      tabs.push({
+        id: id,
+        state: my.tabs[id].state,
+        loading: my.tabs[id].loading
+      });
+    });
+    return cb_(null, tabs);
   };
 
   // ### tabs_load_url
@@ -963,6 +975,7 @@ var core_tabs = function(spec, my) {
   common.method(that, 'tabs_show', tabs_show, _super);
   common.method(that, 'tabs_focus', tabs_focus, _super);
   common.method(that, 'tabs_get', tabs_get, _super);
+  common.method(that, 'tabs_list', tabs_list, _super);
   common.method(that, 'tabs_load_url', tabs_load_url, _super);
   common.method(that, 'tabs_back_or_forward', tabs_back_or_forward, _super);
   common.method(that, 'tabs_reload', tabs_reload, _super);


### PR DESCRIPTION
This PR is associated with issue #152. It adds the method #tabs_list to help make core module methods more consistent.

Output looks like this.
![breach-tabs-list](https://cloud.githubusercontent.com/assets/945367/3634869/7facb3d2-0f4e-11e4-8b49-b1a97df959e5.png)
# tabs_get method now calls #tabs_list when no arguments are provided.
