### PR TITLE
Adding 'Open in New Tab' in context menu if invoked with URL.

### DIFF
--- a/lib/core_tabs.js
+++ b/lib/core_tabs.js
@@ -200,6 +200,32 @@ var core_tabs = function(spec, my) {
         });
       }, function(err) {
         var final = [];
+
+        // Add an extra entry if the click target contains a URL 
+        if(params.link_url.length > 0) {
+          final.push({
+            item: 'Open in New Tab',
+            trigger: function() {
+              tabs_new('core', { 
+                visible: false,
+                focus: false,
+                url: params.link_url
+              }, function(err, res) {
+                if(err) {
+                  common.log.error(err);
+                }
+                else {
+                  my.session.module_manager().core_emit('tabs:created', {
+                    disposition: 'new_background_tab',
+                    id: res.id
+                  });
+                  push_state();
+                }
+              });
+            }
+          });
+        }
+
         Object.keys(items).forEach(function(src) {
           if(final.length > 0) {
             final.push({ item: null });


### PR DESCRIPTION
Right clicking on a link adds 'Open in New Tab' to the context menu. This does what it says on the tin...

This needs a thorough CR, I have no idea if it is the right way to create a new background tab.

Fixes #165.
