### PR TITLE
Fix for #106. Creates a new tab for module config through context menu

### DIFF
--- a/lib/core_tabs.js
+++ b/lib/core_tabs.js
@@ -223,14 +223,22 @@ var core_tabs = function(spec, my) {
         final.push({ 
           item: 'Configure modules',
           trigger: function() {
-            tabs_show('core', { 
-              id: my.NEW_TAB_ID,
-              focus: true
-            }, function() {
-              tabs_load_url('core', {
-                id: my.NEW_TAB_ID,
-                url: my.core_module.core_ui().url_for_ui('modules')
-              }, function() {});
+
+            tabs_new('core', { 
+              visible: true,
+              focus: true,
+              url: my.core_module.core_ui().url_for_ui('modules')
+            }, function(err, res) {
+              if(err) {
+                common.log.error(err);
+              }
+              else {
+                my.session.module_manager().core_emit('tabs:created', {
+                  disposition: 'new_foreground_tab',
+                  id: res.id
+                });
+                push_state();
+              }
             });
           }
         });


### PR DESCRIPTION
Module configuration is now open in a new regular tab.

Fixes #106 .
