### PR TITLE
Send tabs:created event in tabs_new

### DIFF
--- a/lib/core_tabs.js
+++ b/lib/core_tabs.js
@@ -565,6 +565,16 @@ var core_tabs = function(spec, my) {
       },
       function(cb_) {
         push_state();
+        // if the 'id' was not provided, we inform the module manager of the 
+        // tab creation
+        if(!args.id){
+          var disposition = 
+            args.visible ? 'new_foreground_tab' : 'new_background_tab';
+          my.session.module_manager().core_emit('tabs:created', {
+            disposition: disposition,
+            id: t.id
+          });
+        }
         return cb_();
       }
     ], function(err) {


### PR DESCRIPTION
This let the modules know a new tab has been created.

Fixes #178.
