### PR TITLE
Expose common.js through breach_module

### DIFF
--- a/module/index.js
+++ b/module/index.js
@@ -1,6 +1,7 @@
 var common = require('./lib/common.js');
 
 module.exports = require('./lib/module.js').module({});
+module.exports.common = common;
 
 // SAFETY NET (kills the process and the spawns)
 process.on('uncaughtException', function (err) {


### PR DESCRIPTION
Hi,

Currently the wiki states that we have to [make a copy of common.js](https://github.com/breach/breach_core/wiki/Creating-a-new-module#debugging-the-module) when creating a new module. Couldn't it be exposed through the breach_module package ?

``` js
var breach = require('breach_module');
var common = breach.common;
```

I'm currently hacking away with

``` js
var common = require('breach_module/lib/common');
```

but this doesn't feel quite right.
