### PR TITLE
Send tabs:removed event in tabs_close

### DIFF
--- a/lib/core_tabs.js
+++ b/lib/core_tabs.js
@@ -623,6 +623,9 @@ var core_tabs = function(spec, my) {
       function(cb_) {
         if(global.gc) global.gc();
         push_state();
+        my.session.module_manager().core_emit('tabs:removed', {
+          id: t.id
+        });
         return cb_();
       }
     ], cb_);


### PR DESCRIPTION
Broadcast tabs:removed event in tabs_close to all modules such that other modules can update their states. Fix #189 
