### PR TITLE
Simplify Linux README for new users.

### DIFF
--- a/dist/LINUX_README.md
+++ b/dist/LINUX_README.md
@@ -1,37 +1,64 @@
-### Breach README
+## Breach README
+
+Breach currently requires some coaxing to run under most linux
+distributions. There are two known issues that you may run into --
+both occur immediately after running breach like so:
+
+```
+./breach
+```
+
+Solutions to the issues are outlined below.
+
+### `libudev.so.0` problem
+
+`libudev0` has been removed from many recent distributions, which
+stops Breach from running out of the box. One fix is to make a
+symbolic link pointing to your libudev.so.1 file:
+
+```
+sudo ln -sf /lib/$(arch)-linux-gnu/libudev.so.1 /lib/$(arch)-linux-gnu/libudev.so.0
+```
+
+A more dangerous fix is to replace the reference to libudev.so.0 in the
+exo_browser executable with a reference to libudev.so.1. You can
+do that with the following sed command (it's safest to back up the file first):
+
+```
+sed -i 's/udev\.so\.0/udev.so.1/g' __AUTO_UPDATE_BUNDLE__/exo_browser/exo_browser
+```
+
+If you need more information, see these [solutions for missing libudev.so.0](https://github.com/rogerwang/node-webkit/wiki/The-solution-of-lacking-libudev.so.0).
 
 ### SUID Sandbox problem
 
-Breach is based on the Chromium content module which requires a SUID sandbox 
-process to chroot the renderer processes on linux. Running Breach out of the box 
-on linux will probably result in the following error:
+Breach is based on the Chromium content module which requires a
+SUID sandbox process to chroot the renderer processes on linux.
+Running Breach out of the box on linux will probably result in
+the following error:
 
 ```
-[4590:4590:0721/143932:27331338145:FATAL:browser_main_loop.cc(172)] 
-Running without the SUID sandbox! 
-See https://code.google.com/p/chromium/wiki/LinuxSUIDSandboxDevelopment 
+[4590:4590:0721/143932:27331338145:FATAL:browser_main_loop.cc(172)]
+Running without the SUID sandbox!
+See https://code.google.com/p/chromium/wiki/LinuxSUIDSandboxDevelopment
 for more information on developing with the sandbox on.
 Aborted (core dumped)
 ```
 
-To properly handle the access to the sandbox you have the following solutions:
+To properly handle the access to the sandbox, you need to either
+point Breach to an existing `chrome-sandbox`, or install one and
+point there.
 
-**Point Breach to an existing `chrome-sandbox** If you have chrome installed 
-locally you can point Breach to the SUID sandbox locally installed. Depending 
-on your install the path may change, but you should set the following 
-environment variable:
-```
-export CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox
-```
+**Pointing Breach to an existing `chrome-sandbox`** If you have
+chrome installed, you can point Breach to the SUID sandbox
+you've already got. The path could be a number of things, but
+you probably want one of the two following environment variable
+settings:
+`export CHROME_DEVEL_SANDBOX=/opt/google/chrome/chrome-sandbox`, or
+`export CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox`
 
-**Install the `chrome-devel-sandbox`** By following the instructions provided 
-in the error: [LinuxSUIDSandboxDevelopment](https://code.google.com/p/chromium/wiki/LinuxSUIDSandboxDevelopment)
-
-
-### `libudev.so.0` problem
-
-`libudev0` has been removed from recent distributions and prevents from running 
-Breach out of the box resulting in an error at startup.
-
-A great tutorial has been put together for node-webkit that is perfectly 
-applicable for Breach as well: [The solution of lacking libudev.so.0](https://github.com/rogerwang/node-webkit/wiki/The-solution-of-lacking-libudev.so.0)
+**Build your own `chrome-devel-sandbox`** The instructions provided
+in the [LinuxSUIDSandboxDevelopment](https://code.google.com/p/chromium/wiki/LinuxSUIDSandboxDevelopment)
+chromium dev page will tell you how to build the sandbox, which you
+can then point to. You will have to have the chromium source code
+checked out and ready to build.


### PR DESCRIPTION
After trying to install Breach on Xubuntu 14.04 and running into both of
these issues, I'm suggesting this rewrite for the README in the hopes that
it can help new users get through the process more easily.

The salient changes are:
- Add a bit of preamble to orient a new user, informing them that there are
  two common problems
- Reorder the issues to present them in the order they occur
- Directly offer specific solutions for libudev.so.0, instead of linking to
  an outside page
- Add a second suggested chrome-sandbox path.
